### PR TITLE
feat: overwrite completion cache only if changed

### DIFF
--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -1,4 +1,7 @@
+(( $+commands[base64] )) || base64 --help  # trigger error
 ZSH_SMARTCACHE_DIR=${ZSH_SMARTCACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/zsh-smartcache}
+[[ -d $ZSH_SMARTCACHE_DIR ]] || mkdir -p $ZSH_SMARTCACHE_DIR
+fpath+=($ZSH_SMARTCACHE_DIR)
 
 _smartcache-eval() {
     local cache=$ZSH_SMARTCACHE_DIR/eval-$1; shift
@@ -29,14 +32,10 @@ _smartcache-comp() {
             print "Cache updated: '$@' (applied next time)"
         } &!
     }
-    fpath+=($ZSH_SMARTCACHE_DIR)
 }
 
 smartcache() {
     emulate -LR zsh -o extended_glob -o err_return
-
-    (( $+commands[base64] )) || base64 --help  # trigger error
-    [[ -d $ZSH_SMARTCACHE_DIR ]] || mkdir -p $ZSH_SMARTCACHE_DIR
 
     local subcmd=$1; shift
     local id=${$(base64 <<< "$@")%%=#}

--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -3,13 +3,13 @@ ZSH_SMARTCACHE_DIR=${ZSH_SMARTCACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/zsh-sma
 _smartcache-eval() {
     local cache=$ZSH_SMARTCACHE_DIR/eval-$1; shift
     if [[ ! -f $cache ]] {
-        local output=$("$@")
+        local output="$($@)"
         eval $output
         printf '%s' $output >| $cache &!
     } else {
         source $cache
         {
-            local output=$("$@")
+            local output="$($@)"
             [[ $output == "$(<$cache)" ]] && return
             printf '%s' $output >| $cache
             print "Cache updated: '$@' (applied next time)"

--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -6,13 +6,13 @@ fpath+=($ZSH_SMARTCACHE_DIR)
 _smartcache-eval() {
     local cache=$ZSH_SMARTCACHE_DIR/eval-$1; shift
     if [[ ! -f $cache ]] {
-        local output="$($@)"
+        local output=$("$@")
         eval $output
         printf '%s' $output >| $cache &!
     } else {
         source $cache
         {
-            local output="$($@)"
+            local output=$("$@")
             [[ $output == "$(<$cache)" ]] && return
             printf '%s' $output >| $cache
             print "Cache updated: '$@' (applied next time)"
@@ -26,7 +26,7 @@ _smartcache-comp() {
         "$@" >| $cache
     } else {
         {
-            local output="$($@)"
+            local output=$("$@")
             [[ $output == "$(<$cache)" ]] && return
             printf '%s' $output >| $cache
             print "Cache updated: '$@' (applied next time)"

--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -22,7 +22,12 @@ _smartcache-comp() {
     if [[ ! -f $cache ]] {
         "$@" >| $cache
     } else {
-        "$@" >| $cache &!
+        {
+            local output="$($@)"
+            [[ $output == "$(<$cache)" ]] && return
+            printf '%s' $output >| $cache
+            print "Cache updated: '$@' (applied next time)"
+        } &!
     }
     fpath+=($ZSH_SMARTCACHE_DIR)
 }


### PR DESCRIPTION
Implement similar feature for completion as eval.

I have a function that zcompile the zcompdump only if there is a completion in the fpath with a more recent timestamp. The current implementation causes the zcompile to run on every init, which adds significant time to startup.