### PR TITLE
feat: zcompile eval cache

### DIFF
--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -7,7 +7,7 @@ _smartcache-eval() {
         eval $output
         {
             printf '%s' $output >| $cache
-            zcompile $cache
+            zcompile -UR $cache
         } &!
     } else {
         source $cache
@@ -15,7 +15,7 @@ _smartcache-eval() {
             local output=$("$@")
             [[ $output == "$(<$cache)" ]] && return
             printf '%s' $output >| $cache
-            zcompile $cache
+            zcompile -UR $cache
             print "Cache updated: '$@' (applied next time)"
         } &!
     }

--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -7,7 +7,7 @@ _smartcache-eval() {
         eval $output
         {
             printf '%s' $output >| $cache
-            zcompile -R $cache
+            zcompile $cache
         } &!
     } else {
         source $cache
@@ -16,7 +16,7 @@ _smartcache-eval() {
             [[ $output == "$(<$cache)" ]] && return
             eval $output
             printf '%s' $output >| $cache
-            zcompile -R $cache
+            zcompile $cache
             print "Cache updated: '$@' (applied next time)"
         } &!
     }

--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -8,7 +8,7 @@ _smartcache-eval() {
         {
             printf '%s' $output >| $cache
             zcompile $cache
-        }&!
+        } &!
     } else {
         source $cache
         {

--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -5,13 +5,17 @@ _smartcache-eval() {
     if [[ ! -f $cache ]] {
         local output=$("$@")
         eval $output
-        printf '%s' $output >| $cache &!
+        {
+            printf '%s' $output >| $cache
+            zcompile $cache
+        }&!
     } else {
         source $cache
         {
             local output=$("$@")
             [[ $output == "$(<$cache)" ]] && return
             printf '%s' $output >| $cache
+            zcompile $cache
             print "Cache updated: '$@' (applied next time)"
         } &!
     }

--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -7,15 +7,16 @@ _smartcache-eval() {
         eval $output
         {
             printf '%s' $output >| $cache
-            zcompile -UR $cache
+            zcompile -R $cache
         } &!
     } else {
         source $cache
         {
             local output=$("$@")
             [[ $output == "$(<$cache)" ]] && return
+            eval $output
             printf '%s' $output >| $cache
-            zcompile -UR $cache
+            zcompile -R $cache
             print "Cache updated: '$@' (applied next time)"
         } &!
     }

--- a/zsh-smartcache.plugin.zsh
+++ b/zsh-smartcache.plugin.zsh
@@ -14,8 +14,8 @@ _smartcache-eval() {
         {
             local output=$("$@")
             [[ $output == "$(<$cache)" ]] && return
-            eval $output
             printf '%s' $output >| $cache
+            source $cache
             zcompile $cache
             print "Cache updated: '$@' (applied next time)"
         } &!


### PR DESCRIPTION
zcompile can potentially reduce source time by 50%. I think it is worthwile to include. Apologies, it looks like there is more code repetitions, but I think it's fine for the small codebase.

I don't think it is necessary to zcompile completions as the user should zcompile the `zcompdump` file if that is the intention.

I tested with `fzf --zsh`.


|                  | `time (repeat 10000 {})`                                    | output                                           |
|------------------|------------------------------------------------------|--------------------------------------------------|
| raw              | `source <(fzf --zsh)`                                | `20.99s user 13.33s system 95% cpu 35.877 total` |
| without zcompile | `source ~/.cache/zsh-smartcache/eval-ZnpmIC0tenNoCg` | `9.97s user 2.00s system 94% cpu 12.724 total`   |
| with zcompile    | `source ~/.cache/zsh-smartcache/eval-ZnpmIC0tenNoCg` | `4.73s user 1.29s system 89% cpu 6.744 total`    |